### PR TITLE
Fix for continue to process fast5-files

### DIFF
--- a/modules/MyHandler.py
+++ b/modules/MyHandler.py
@@ -325,8 +325,6 @@ class MyHandler(FileSystemEventHandler):
                                 % (fast5file, err)
                             #print >> sys.stderr, err_string
                             print err_string
-			
-			    return ()
 
 			'''
                                                                                                 #               if dbname is not None:


### PR DESCRIPTION
When a incorrect fast5 file is detected minUP stops to process files.
