### PR TITLE
Don't assume each reference contains one record.

### DIFF
--- a/modules/processRefFasta.py
+++ b/modules/processRefFasta.py
@@ -124,11 +124,11 @@ def process_ref_fasta(
                 sys.exit(1)
         valid_fasta_handle.close()
 
-    n = len(files)
-    bar = mkBar(n)
+    records = list(SeqIO.parse(validated_ref, 'fasta'))
+    bar = mkBar(len(records))
     bar.start()
     x=0
-    for record in SeqIO.parse(validated_ref, 'fasta'):
+    for record in records:
 	bar.update(x)
 	x+=1
 	    


### PR DESCRIPTION
A progressbar was assuming that the number of
reference files provided was equal to the number of
fasta records in the `validated_ref` file. In fact, each
fasta reference file could contain more than one record.
Providing a reference with more than one record in it
was causing a traceback when the progress bar was
updated to a number higher than its maximum value.

This patch changes the progress bar to be based on the
number of records in the `validated_ref` file. This means
using a list rather than an iterator, so might cause an
increase in memory usage, but I think this will be very
small and temporary, and a similar list is used
earlier in `processRefFasta`.
