### PR TITLE
Cope with h5py error

### DIFF
--- a/modules/folderDict.py
+++ b/modules/folderDict.py
@@ -38,8 +38,8 @@ def moveFile(args, fast5file):
 
 # ---------------------------------------------------------------------------
 def getHDFtime(args, f):
-    with h5py.File(f) as hdf:
-        try:
+    try:
+        with h5py.File(f) as hdf:
             expStartTime = \
                     hdf['UniqueGlobalKey/tracking_id'].attrs['exp_start_time']
             reads = 'Analyses/EventDetection_000/Reads/'
@@ -58,8 +58,8 @@ def getHDFtime(args, f):
                     readTime = endTime
 
             timestamp =  int(expStartTime) + int(readTime)
-        except:
-            timestamp = -1
+    except:
+        timestamp = -1
     return timestamp
     
 

--- a/modules/folderDict.py
+++ b/modules/folderDict.py
@@ -58,7 +58,6 @@ def getHDFtime(args, f):
                     readTime = endTime
 
             timestamp =  int(expStartTime) + int(readTime)
-            hdf.close()
         except:
             timestamp = -1
     return timestamp

--- a/modules/folderDict.py
+++ b/modules/folderDict.py
@@ -45,17 +45,17 @@ def getHDFtime(args, f):
             reads = 'Analyses/EventDetection_000/Reads/'
 
             for read in hdf[reads]:
-                    '''
-                    # 0.64a .. 
-                    startTime = hdf[ reads + read ].attrs['start_time'] 
-                    readTime = startTime
-                    '''
-                    # 0.64b ...
-                    # End time is Start time of final event 
-                    #endTime = hdf[ reads + read + "/Events"][-1][-2] 
-                    endTime = hdf[ reads + read + "/Events"].attrs['start'][-1    ]
+                '''
+                # 0.64a .. 
+                startTime = hdf[ reads + read ].attrs['start_time'] 
+                readTime = startTime
+                '''
+                # 0.64b ...
+                # End time is Start time of final event 
+                #endTime = hdf[ reads + read + "/Events"][-1][-2] 
+                endTime = hdf[ reads + read + "/Events"].attrs['start'][-1    ]
 
-                    readTime = endTime
+                readTime = endTime
 
             timestamp =  int(expStartTime) + int(readTime)
     except:

--- a/modules/folderDict.py
+++ b/modules/folderDict.py
@@ -39,7 +39,7 @@ def moveFile(args, fast5file):
 # ---------------------------------------------------------------------------
 def getHDFtime(args, f):
     try:
-        with h5py.File(f) as hdf:
+        with h5py.File(f, 'r') as hdf:
             expStartTime = \
                     hdf['UniqueGlobalKey/tracking_id'].attrs['exp_start_time']
             reads = 'Analyses/EventDetection_000/Reads/'


### PR DESCRIPTION
Hi Matt

I'm getting a strange error from h5py

```
line 104, in make_fid
  File "h5f.pyx", line 90, in h5py.h5f.create (h5py/h5f.c:1975)
IOError: Unable to create file (Unable to open file: name =
'<oddly lower cased fast5 file path>',
errno = 17, error message = 'file exists', flags = 15, o_flags = c2)
```

I suspect this is an example of https://github.com/h5py/h5py/issues/704.

This happens at https://github.com/minoTour/linminUP/blob/master/modules/folderDict.py#L41.

The problem appears to be that h5py can't parse the file and raises an exception. Because this happens as the file is opened in the `with` statement itself rather than in the block which follows it, the exception handling which should set `timestamp` to `-1` isn't triggered and instead the thread fails. I suggest swapping the try and the with so that in these circumstances the error does get handled.

Cheers,

Duncan
